### PR TITLE
Fix timeout example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,13 @@ thingShadows.on('status',
 
 thingShadows.on('delta', 
     function(thingName, stateObject) {
-       console.log('received delta '+' on '+thingName+': '+
+       console.log('received delta on '+thingName+': '+
                    JSON.stringify(stateObject));
     });
 
 thingShadows.on('timeout',
     function(thingName, clientToken) {
-       console.log('received timeout '+' on '+operation+': '+
-                   clientToken);
+       console.log('received timeout on operation with token: '+clientToken);
     });
 ```
 


### PR DESCRIPTION
Fixes timeout example in README: `timeout` event doesn't return `operation`.