### PR TITLE
Add protocol option support

### DIFF
--- a/device/index.js
+++ b/device/index.js
@@ -48,7 +48,12 @@ module.exports = function(options) {
   {
      options.port = 8883;
   }
-  options.protocol = 'mqtts';
+
+  // set protocol
+  if (isUndefined(options.protocol))
+  {
+     options.protocol = 'mqtts';
+  }
   
   if (isUndefined(options.host))
   {
@@ -63,7 +68,10 @@ module.exports = function(options) {
   }
 
   //read and map certificates
-  tlsReader(options);
+  if (options.protocol == 'mqtts')
+  {
+     tlsReader(options);
+  }
 
   if ((!isUndefined(options)) && (options.debug===true))
   {


### PR DESCRIPTION
I want to use MQTT->MQTTS Proxy in front of AWS IoT Data API.
For example, [SORACOM Beam](https://soracom.jp/services/beam/) can use.
It adds X509 Certifications to MQTT packet when forwarding to AWS IoT Data API.