### PR TITLE
Ignore node only modules for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,10 @@
     "test": "node ./node_modules/gulp/bin/gulp.js test --verbose",
     "browserize": "./scripts/browserize.sh",
     "beautify": "node ./node_modules/gulp/bin/gulp.js beautify"
+  },
+  "browser": {
+    "fs": false,
+    "tls": false,
+    "net": false
   }
 }


### PR DESCRIPTION
Use browser param in package.json so that webpack won’t try and include fs, tls and net