### PR TITLE
Import the MqttClient constructor directly

### DIFF
--- a/device/index.js
+++ b/device/index.js
@@ -19,6 +19,7 @@ const inherits = require('util').inherits;
 
 //npm deps
 const mqtt = require('mqtt');
+const MqttClient = require('mqtt/lib/client');
 const crypto = require('crypto-js');
 
 //app deps
@@ -506,7 +507,7 @@ function DeviceClient(options) {
       return protocols[options.protocol](client, options);
    }
 
-   const device = new mqtt.MqttClient(_wrapper, options);
+   const device = new MqttClient(_wrapper, options);
 
    //handle events from the mqtt client
 

--- a/scripts/browserize.sh
+++ b/scripts/browserize.sh
@@ -49,11 +49,6 @@ then
 #
             (cd $BROWSER_BUNDLE_DIR; tar cvzf aws-iot-device-sdk.tgz --exclude ${PWD##*/} --exclude node_modules --exclude .git --exclude .coverdata --exclude debug --exclude examples --exclude reports --exclude test -C ../ .; mkdir -p node_modules/aws-iot-device-sdk; (cd node_modules/aws-iot-device-sdk; tar xvzf ../../aws-iot-device-sdk.tgz); npm install)
 #
-# Patch mqtt.js so that we have access to its internal client constructor (needed so that we 
-# can dynamically create the URL).
-#
-            (cd $BROWSER_BUNDLE_DIR/node_modules/mqtt/lib/connect; echo "module.exports.MqttClient = MqttClient;" >> index.js)
-#
 # Finally, create the browser bundle and delete all working files/directories.  Note
 # that we allow aws-iot-device-sdk and aws-sdk to be required by other browserify bundles.
 #


### PR DESCRIPTION
Although this is still fairly brittle it means you don't need to patch a dependency with a script! 

(It'll break if the mqtt project refactor and move the client class)