### PR TITLE
Adding callback to thingShadow.register

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,18 +130,11 @@ thingShadows.on('connect', function() {
 // After connecting to the AWS IoT platform, register interest in the
 // Thing Shadow named 'RGBLedLamp'.
 //
-    thingShadows.register( 'RGBLedLamp' );
-//
-// 5 seconds after registering, update the Thing Shadow named 
+    thingShadows.register( 'RGBLedLamp', function() {
+
+// When the Thing Shadow is ready, update the Thing Shadow named
 // 'RGBLedLamp' with the latest device state and save the clientToken
 // so that we can correlate it with status or timeout events.
-//
-// Note that the delay is not required for subsequent updates; only
-// the first update after a Thing Shadow registration using default
-// parameters requires a delay.  See API documentation for the update
-// method for more details.
-//
-    setTimeout( function() {
 //
 // Thing shadow state
 //
@@ -160,7 +153,6 @@ thingShadows.on('connect', function() {
        {
           console.log('update shadow failed, operation still in progress');
        }
-       }, 5000 );
     });
 
 thingShadows.on('status', 
@@ -333,7 +325,7 @@ from each operation.
 
 -------------------------------------------------------
 <a name="register"></a>
-### awsIot.thingShadow#register(thingName, [options] )
+### awsIot.thingShadow#register(thingName, [options], [callback] )
 
 Register interest in the Thing Shadow named `thingName`.  The thingShadow class will
 subscribe to any applicable topics, and will fire events for the Thing Shadow
@@ -363,6 +355,10 @@ If `enableVersioning` is set to true, version numbers will be sent with each ope
 AWS IoT maintains version numbers for each shadow, and will reject operations which 
 contain the incorrect version; in applications where multiple clients update the same
 shadow, clients can use versioning to avoid overwriting each other's changes.
+
+The `callback` parameter are optional and will be called when the thingShadow is read for use.
+*Ready for use* means when we have received subscription ACK on all needed topics. 
+The callback should be used when delete/get/update operations is needed right after the thingShadow is ready.
 
 -------------------------------------------------------
 <a name="unregister"></a>

--- a/test/mock/mockMQTTClient.js
+++ b/test/mock/mockMQTTClient.js
@@ -18,7 +18,6 @@ function mockMQTTClient( wrapper, options ) {
         this.subscribeQosValues.length = 0;
         this.publishQosValues = new Array;
         this.publishQosValues.length = 0;
-        this.triggerError = null;
 
 	// Reinit the record list
 	this.reInitCommandCalled = function() {
@@ -79,7 +78,7 @@ function mockMQTTClient( wrapper, options ) {
                          grantedTopic.qos = options.qos;
                       }
 
-                      if (that.triggerError) {
+                      if (mockMQTTClient.triggerError()) {
                          grantedTopic.qos = 128;
                       }
 
@@ -93,7 +92,7 @@ function mockMQTTClient( wrapper, options ) {
                          that.subscribeQosValues.push( options.qos );
                          grantedTopic.qos = options.qos;
                       }
-                      if (this.triggerError) {
+                      if (mockMQTTClient.triggerError()) {
                          grantedTopic.qos = 128;
                       }
                       granted.push(grantedTopic);
@@ -123,4 +122,9 @@ function mockMQTTClient( wrapper, options ) {
 }
 
 util.inherits(mockMQTTClient, EventEmitter);
+
+mockMQTTClient.triggerError = function() {
+  return false;
+};
+
 module.exports = mockMQTTClient;

--- a/test/mock/mockMQTTClient.js
+++ b/test/mock/mockMQTTClient.js
@@ -18,6 +18,7 @@ function mockMQTTClient( wrapper, options ) {
         this.subscribeQosValues.length = 0;
         this.publishQosValues = new Array;
         this.publishQosValues.length = 0;
+        this.triggerError = null;
 
 	// Reinit the record list
 	this.reInitCommandCalled = function() {
@@ -68,22 +69,37 @@ function mockMQTTClient( wrapper, options ) {
 		callback = callback || '';
 		this.commandCalled['subscribe'] += 1;
 
+                var granted = [];
                 if ( Object.prototype.toString.call(topic) === '[object Array]' ) {
                    topic.forEach( function( item, index, array ) {
+                      var grantedTopic = {topic: item, qos: 0}
                       that.subscriptions.push( item );
                       if (!isUndefined( options.qos )) {
                          that.subscribeQosValues.push( options.qos );
+                         grantedTopic.qos = options.qos;
                       }
+
+                      if (that.triggerError) {
+                         grantedTopic.qos = 128;
+                      }
+
+                      granted.push(grantedTopic);
                    });
                 }
                 else {
+                   var grantedTopic = {topic: topic, qos: 0}
                    this.subscriptions.push( topic );
                       if (!isUndefined( options.qos )) {
                          that.subscribeQosValues.push( options.qos );
+                         grantedTopic.qos = options.qos;
                       }
+                      if (this.triggerError) {
+                         grantedTopic.qos = 128;
+                      }
+                      granted.push(grantedTopic);
                 }
 		if(callback !== '') {
-			callback(null); // call callback
+			callback(null, granted); // call callback
 		}
     };
 

--- a/test/thing-unit-tests.js
+++ b/test/thing-unit-tests.js
@@ -85,18 +85,7 @@ describe( "thing shadow class unit tests", function() {
 
       it("should trigger error when a subscription fails", function () {
 
-        // Need local stub to trigger error, so just copy-paste the code
-        var localMockMqtt;
-        var fakeConnect = function (options) {
-          mockMQTTClientObject = new mockMQTTClient(); // return the mocking object
-          mockMQTTClientObject.reInitCommandCalled();
-          mockMQTTClientObject.resetPublishedMessage();
-          mockMQTTClientObject.triggerError = true;
-          return mockMQTTClientObject;
-        };
-
-        mqttSave.restore();
-        mqttSave = sinon.stub(device, 'DeviceClient', fakeConnect);
+        var stubTriggerError = sinon.stub(mockMQTTClient, 'triggerError', function(){return true;});
 
         var thingShadows = thingShadow(thingShadowsConfig);
         thingShadows.register('testShadow1', { ignoreDeltas: true, persistentSubscribe: true }, function (err, granted) {
@@ -106,6 +95,7 @@ describe( "thing shadow class unit tests", function() {
             // 128 is 0x80 - Failure from the MQTT lib.
             //
             assert.equal(granted[k].qos, 128);
+            stubTriggerError.restore();
           }
         });
       });

--- a/test/thing-unit-tests.js
+++ b/test/thing-unit-tests.js
@@ -69,6 +69,53 @@ describe( "thing shadow class unit tests", function() {
       });
    });
 
+   describe( "register a thing shadow name should trigger callback", function() {
+//
+// Verify that the thing shadow invokes the register callback when subscription to all
+// topics are finished. The callback is invoked based on the callback from the mqtt library.
+//
+
+      var thingShadowsConfig = {
+         keyPath: 'test/data/private.pem.key',
+         certPath: 'test/data/certificate.pem.crt',
+         caPath: 'test/data/root-CA.crt',
+         clientId: 'dummy-client-1',
+         region: 'us-east-1'
+      };
+
+      it("when ignoreDeltas is true and persistentSubscribe is true", function() {
+            var thingShadows = thingShadow( thingShadowsConfig );
+            var fakeCallback = sinon.spy();
+            thingShadows.register( 'testShadow1', {ignoreDeltas:true, persistentSubscribe:true}, fakeCallback);
+
+            assert(fakeCallback.calledOnce);
+      });
+
+      it("when ignoreDeltas is false and persistentSubscribe is false", function() {
+            var thingShadows = thingShadow( thingShadowsConfig );
+            var fakeCallback = sinon.spy();
+            thingShadows.register( 'testShadow1', {ignoreDeltas:false, persistentSubscribe:false}, fakeCallback);
+
+            assert(fakeCallback.calledOnce);
+      });
+
+      it("when ignoreDeltas is true and persistentSubscribe is false", function() {
+            var thingShadows = thingShadow( thingShadowsConfig );
+            var fakeCallback = sinon.spy();
+            thingShadows.register( 'testShadow1', {ignoreDeltas:true, persistentSubscribe:false}, fakeCallback);
+
+            assert(fakeCallback.calledOnce);
+      });
+
+      it("when ignoreDeltas is false and persistentSubscribe is true", function() {
+            var thingShadows = thingShadow( thingShadowsConfig );
+            var fakeCallback = sinon.spy();
+            thingShadows.register( 'testShadow1', {ignoreDeltas:false, persistentSubscribe:true}, fakeCallback);
+
+            assert(fakeCallback.calledOnce);
+      });
+   });
+
    describe( "subscribe to/unsubscribe from a non-thing topic", function() {
 //
 // Verify that the thing shadow module does not throw an exception


### PR DESCRIPTION
- Update the thing register function with a completion callback
- Add new test for the different states (ignoreDelta and persistentSubscribe)
- Updated README.md to reflect the new changes

Fixes issue #80 if I understood the aws and mqtt implementation correct. The new code waits for the mqtt lib to invoke the callback on _ignoreDeltas_ and _persistentSubscribe_ topics. When the mqtt lib has invoked both callbacks, will the register function invoke the register callback.

Maybe need for some more test cases, but please review and provide with feedback :) 
