### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ thingShadows.on('connect', function() {
 // After connecting to the AWS IoT platform, register interest in the
 // Thing Shadow named 'RGBLedLamp'.
 //
-    thingShadows.register( 'RGBLedLamp', function() {
+    thingShadows.register( 'RGBLedLamp', {}, function() {
 
 // Once registration is complete, update the Thing Shadow named
 // 'RGBLedLamp' with the latest device state and save the clientToken


### PR DESCRIPTION
Issue in the example.

thingShadow.register has 3 arguments, the 3rd being the callback, so a empty options argument is needed for this example