### PR TITLE
protect from undefined granted variable

### DIFF
--- a/thing/index.js
+++ b/thing/index.js
@@ -162,7 +162,7 @@ function ThingShadowsClient(deviceOptions, thingShadowOptions) {
          });
          // add our callback to check the SUBACK response for granted subscriptions
          args.push(function(err, granted) {
-            if (!isUndefined(callback)) {
+            if (!isUndefined(callback) && !isUndefined(granted)) {
                if (err) {
                   callback(err);
                   return;


### PR DESCRIPTION
Hi,
Using this lib, we came across the following bug after a while:

```
[2016-12-16 07:02:45.616] [ERROR] embedded-app-stderr - /usr/lib/node_modules/aws-iot-device-sdk/thing/index.js:174

[2016-12-16 07:02:45.622] [ERROR] embedded-app-stderr -                for (var k = 0, grantedLen = granted.length; k < grantedLen; k++) {
                                                   ^

TypeError: Cannot read property 'length' of undefined
    at /usr/lib/node_modules/aws-iot-device-sdk/thing/index.js:174:52
    at that.outgoing.(anonymous function) (/usr/lib/node_modules/aws-iot-device-sdk/node_modules/mqtt/lib/client.js:138:15)
    at /usr/lib/node_modules/aws-iot-device-sdk/node_modules/mqtt/lib/client.js:845:9
    at Store.del (/usr/lib/node_modules/aws-iot-device-sdk/node_modules/mqtt/lib/store.js:76:5)
    at MqttClient._handleAck (/usr/lib/node_modules/aws-iot-device-sdk/node_modules/mqtt/lib/client.js:831:26)
    at MqttClient._handlePacket (/usr/lib/node_modules/aws-iot-device-sdk/node_modules/mqtt/lib/client.js:284:12)
    at process (/usr/lib/node_modules/aws-iot-device-sdk/node_modules/mqtt/lib/client.js:233:12)
    at Writable.writable._write (/usr/lib/node_modules/aws-iot-device-sdk/node_modules/mqtt/lib/client.js:243:5)
    at doWrite (/usr/lib/node_modules/aws-iot-device-sdk/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/lib/node_modules/aws-iot-device-sdk/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at Writable.write (/usr/lib/node_modules/aws-iot-device-sdk/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at TLSSocket.ondata (_stream_readable.js:529:20)
    at emitOne (events.js:90:13)
    at TLSSocket.emit (events.js:182:7)
    at readableAddChunk (_stream_readable.js:147:16)
    at TLSSocket.Readable.push (_stream_readable.js:111:10)
    at TLSWrap.onread (net.js:523:20)
```

This commit tries to fix the problem. The bug is not easily reproducible.