### PR TITLE
Fix sample's grammatical error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ thingShadows.on('timeout',
 // call to get(), update(), or delete().
 //
     });
-
+    
+});
 ```
 
 <a name="api"></a>


### PR DESCRIPTION
## Overview
Fix sample's grammatical error in README.md.

( README.md ) Line-188 : missing `}` and `)` which correspond with `{`,`(` in Line-128