### PR TITLE
Fix `ReferenceError: isUndefined is not defined` error

### DIFF
--- a/common/lib/tls-reader.js
+++ b/common/lib/tls-reader.js
@@ -14,13 +14,13 @@
  */
 
 //node.js deps
-const filesys = require('fs');
+var filesys = require('fs');
 
 //npm deps
 
 //app deps
-const isUndefined = require('./is-undefined');
-const exceptions = require('./exceptions');
+var isUndefined = require('./is-undefined');
+var exceptions = require('./exceptions');
 
 //begin module
 /**

--- a/device/index.js
+++ b/device/index.js
@@ -14,17 +14,17 @@
  */
 
 //node.js deps
-const events = require('events');
-const inherits = require('util').inherits;
+var events = require('events');
+var inherits = require('util').inherits;
 
 //npm deps
-const mqtt = require('mqtt');
-const crypto = require('crypto-js');
+var mqtt = require('mqtt');
+var crypto = require('crypto-js');
 
 //app deps
-const exceptions = require('./lib/exceptions'),
-   isUndefined = require('../common/lib/is-undefined'),
-   tlsReader = require('../common/lib/tls-reader');
+var exceptions = require('./lib/exceptions');
+var isUndefined = require('../common/lib/is-undefined');
+var tlsReader = require('../common/lib/tls-reader');
 
 //begin module
 function makeTwoDigits(n) {

--- a/device/lib/ws.js
+++ b/device/lib/ws.js
@@ -16,7 +16,7 @@
 //node.js deps
 
 //npm deps
-const websocket = require('websocket-stream');
+var websocket = require('websocket-stream');
 
 //app deps
 

--- a/thing/index.js
+++ b/thing/index.js
@@ -14,14 +14,14 @@
  */
 
 //node.js deps
-const events = require('events');
-const inherits = require('util').inherits;
+var events = require('events');
+var inherits = require('util').inherits;
 
 //npm deps
 
 //app deps
-const deviceModule = require('../device');
-const isUndefined = require('../common/lib/is-undefined');
+var deviceModule = require('../device');
+var isUndefined = require('../common/lib/is-undefined');
 
 //
 // private functions


### PR DESCRIPTION
This PR fixes #117 [`ReferenceError: isUndefined is not defined`](https://github.com/aws/aws-iot-device-sdk-js/issues/117) by changing all of the instances of

```
const xyz = require('xyz');
```
to

```
var xyz = require('xyz');
```

Please let me know if there's anything further I can do to help with this PR.

Thanks!