### PR TITLE
thingShadow.register options param now optional

### DIFF
--- a/test/thing-unit-tests.js
+++ b/test/thing-unit-tests.js
@@ -133,6 +133,14 @@ describe( "thing shadow class unit tests", function() {
 
             assert(fakeCallback.calledOnce);
       });
+
+      it("should trigger callback when no options are provided", function() {
+            var thingShadows = thingShadow( thingShadowsConfig );
+            var fakeCallback = sinon.spy();
+            thingShadows.register( 'testShadow1', fakeCallback);
+
+            assert(fakeCallback.calledOnce);
+      });
    });
 
    describe( "subscribe to/unsubscribe from a non-thing topic", function() {

--- a/thing/index.js
+++ b/thing/index.js
@@ -561,6 +561,9 @@ function ThingShadowsClient(deviceOptions, thingShadowOptions) {
             if (!isUndefined(options.qos)) {
                thingShadows[thingName].qos = options.qos;
             }
+            if(typeof options === 'function' && isUndefined(callback)){
+               callback = options;
+            }
          }
          //
          // Always listen for deltas unless requested otherwise.


### PR DESCRIPTION
thingShadow.register can now be called with (thingName, callback) without any options parameters.

Fixes #126 