### PR TITLE
fix handleMessage to be overridden rather than pass-through

### DIFF
--- a/device/index.js
+++ b/device/index.js
@@ -764,8 +764,13 @@ function DeviceClient(options) {
    this.end = function(force, callback) {
       device.end(force, callback);
    };
-   this.handleMessage = function(packet, callback) {
-      device.handleMessage(packet, callback);
+
+   // fall back to MqttClient default implementation
+   this.handleMessage = device.handleMessage.bind(device);
+
+   // allow override
+   device.handleMessage = function(packet, callback) {
+      that.handleMessage(packet, callback);
    };
    //
    // Call this function to update the credentials used when

--- a/test/device-unit-tests.js
+++ b/test/device-unit-tests.js
@@ -755,10 +755,24 @@ describe( "device class unit tests", function() {
           mockMQTTClientObject.emit('connect');
           device.end( false, null );
           assert.equal(mockMQTTClientObject.commandCalled['end'], 1); // Called once
-          assert.equal(mockMQTTClientObject.commandCalled['handleMessage'], 0); // Not called yet
-          device.handleMessage( 'message', function() { console.log('callback'); } );
+
+          // simulate overriding handleMessage
+          var expectedPacket = { data: 'some data' };
+          var calledOverride = 0;
+          var calledBack = 0;
+          device.handleMessage = function customHandleMessage(packet, callback) {
+             calledOverride++;
+             assert.deepEqual(packet, expectedPacket);
+             callback();
+          };
+
+          mockMQTTClientObject.handleMessage(expectedPacket, function () {
+            calledBack++;
+            assert.equal(calledOverride, 1);
+            assert.equal(calledBack, 1);
+          });
+
           assert.equal(mockMQTTClientObject.commandCalled['end'], 1); // Called once
-          assert.equal(mockMQTTClientObject.commandCalled['handleMessage'], 1); // Called once
         });
     });
 //

--- a/test/mock/mockMQTTClient.js
+++ b/test/mock/mockMQTTClient.js
@@ -128,6 +128,7 @@ function mockMQTTClient( wrapper, options ) {
 
    this.handleMessage = function(packet, callback) {
       this.commandCalled['handleMessage'] += 1;
+      callback();
    };
 
    EventEmitter.call(this);


### PR DESCRIPTION
handleMessage is designed to be overridden, not passed through, so that the developer using MqttClient can delay the PUBACK. The default implementation in MqttClient is just to call `callback()`: https://github.com/mqttjs/MQTT.js/blob/master/lib/client.js#L869