### PR TITLE
propagate error from 'close' event

### DIFF
--- a/device/index.js
+++ b/device/index.js
@@ -652,7 +652,11 @@ function DeviceClient(options) {
       }
       that.emit('connect');
    });
-   device.on('close', function() {
+   device.on('close', function(err) {
+      if (err) {
+         that.emit('error', err);
+      }
+
       if ((!isUndefined(options)) && (options.debug === true)) {
          console.log('connection lost - will attempt reconnection in ' +
             device.options.reconnectPeriod / 1000 + ' seconds...');


### PR DESCRIPTION
this is really the only way to tell if something went wrong with the connection as MQTT.js swallows all other errors: https://github.com/mqttjs/MQTT.js/issues/623#issuecomment-306489657