### PR TITLE
Update MQTT dependency to address a security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mqtt"
   ],
   "dependencies": {
-    "mqtt": "2.14.0",
+    "mqtt": "2.15.0",
     "minimist": "1.2.0",
     "websocket-stream": "^5.0.1",
     "crypto-js": "3.1.6"


### PR DESCRIPTION
MQTT.js 2.x.x prior to 2.15.0 issue in handling PUBLISH tickets may lead to an attacker causing a denial-of-service https://nvd.nist.gov/vuln/detail/CVE-2017-10910