### PR TITLE
Redirect offline queue handling to MQTT.js

### DIFF
--- a/device/index.js
+++ b/device/index.js
@@ -836,9 +836,7 @@ function DeviceClient(options) {
             });
          }
       } else {
-         if (offlineQueueing === true || !_filling()) {
-            device.publish(topic, message, options, callback);
-         }
+        device.publish(topic, message, options, callback);
       }
    };
    this.subscribe = function(topics, options, callback) {


### PR DESCRIPTION
*Issue #, if available:*
#219 

*Description of changes:*

By default, this SDK handles MQTT's offline queue, but it persists it in memory. By removing this if statement, we make sure that MQTT.js will handle the queue with it's persistency capabilities.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
