### PR TITLE
Correct calling `update` from within `on('timeout')` callback

### DIFF
--- a/test/thing-unit-tests.js
+++ b/test/thing-unit-tests.js
@@ -1529,6 +1529,43 @@ describe( "thing shadow class unit tests", function() {
           // Unregister it
           thingShadows.unregister('testShadow3');
       });
+
+      it("should not fire foreignState when update is triggered from timeout context", function() {
+          // Reinit mockMQTTClientObject
+          mockMQTTClientObject = new mockMQTTClient(); // return the mocking object
+          mockMQTTClientObject.reInitCommandCalled();
+          mockMQTTClientObject.resetPublishedMessage();
+          // Faking timer
+          var clock = sinon.useFakeTimers();
+          // Faking callback
+          var foreignCallback = sinon.spy();
+          // Init thingShadowClient
+          var thingShadows = thingShadow( {
+            keyPath:'test/data/private.pem.key',
+            certPath:'test/data/certificate.pem.crt',
+            caPath:'test/data/root-CA.crt',
+            clientId:'dummy-client-1',
+            host:'XXXX.iot.us-east-1.amazonaws.com',
+          }, {
+            operationTimeout:1000 // Set operation timeout to be 1 sec
+          } );
+          // Register callbacks
+          thingShadows.on('timeout', function () {
+              thingShadows.update('testShadow3', {});
+          });
+          thingShadows.on('foreignStateChange', foreignCallback);
+          // Register a thing
+          thingShadows.register('testShadow3');
+          // Get
+          thingShadows.get('testShadow3', 'CoolToken1');
+          // Delete
+          clock.tick(1000); // 1 sec later...
+          mockMQTTClientObject.emit('message', '$aws/things/testShadow3/shadow/update/accepted', '{"clientToken":"dummy-client-1-0", "version":2}');
+          sinon.assert.notCalled(foreignCallback);
+          // Unregister it
+          thingShadows.unregister('testShadow3');
+          clock.restore();
+      });
     });
 //
 // Verify that shadow operations are performed using the correct qos values

--- a/thing/index.js
+++ b/thing/index.js
@@ -442,17 +442,21 @@ function ThingShadowsClient(deviceOptions, thingShadowOptions) {
                   // Mark this operation as complete.
                   //
                   thingShadows[thingName].pending = false;
+
+                  //
+                  // Delete the timeout handle and client token for this thingName.
+                  //
+                  delete thingShadows[thingName].timeout;
+                  delete thingShadows[thingName].clientToken;
+
                   //
                   // Emit an event for the timeout; the clientToken is included as an argument
                   // so that the application can correlate timeout events to the operations
                   // they are associated with.
                   //
                   that.emit('timeout', thingName, clientToken);
-                  //
-                  // Delete the timeout handle and client token for this thingName.
-                  //
-                  delete thingShadows[thingName].timeout;
-                  delete thingShadows[thingName].clientToken;
+
+
                }, operationTimeout,
                thingName, clientToken);
             //


### PR DESCRIPTION
*Issue #, if available:*
#284 

*Description of changes:*
Moved the state cleanup to before the `emit('timeout')` call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
