### PR TITLE
Added the ability to pass an device object to both the thingShadow and jobs module

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ functionality to operate on Thing Shadows via the AWS IoT API.  The
 arguments in `deviceOptions` include all those in the [device class](#device).
 thingShadowOptions has the addition of the following arguments specific to the `thingShadow` class:
 
+* `device`: a pre-existing device instance for connection reuse
 * `operationTimeout`: the timeout for thing operations (default 10 seconds)
 
 Supports all events emitted by the [mqtt.Client()](https://github.com/mqttjs/MQTT.js/blob/master/README.md#client) class; however, the semantics for the 
@@ -579,6 +580,9 @@ The `jobs` class wraps an instance of the `device` class with additional functio
 handle job execution management through the AWS IoT Jobs platform. Arguments in `deviceOptions` 
 are the same as those in the [device class](#device) and the `jobs` class supports all of the
 same events and functions as the `device` class.
+deviceOptions has the addition of the following arguments specific to the `jobs` class:
+
+* `device`: a pre-existing device instance for connection reuse
 
 The `jobs` class also supports the following methods:
 

--- a/jobs/index.js
+++ b/jobs/index.js
@@ -89,7 +89,6 @@ function jobsClient(options) {
    // Allow reuse of the device client by passing options.device
    if (!isUndefined(options.device) && typeof options.device === "object")
    {
-      console.log(typeof(options.device));
       var device = options.device;
    } else {
       //

--- a/jobs/index.js
+++ b/jobs/index.js
@@ -86,10 +86,18 @@ function jobsClient(options) {
    //
    var jobSubscriptions = [];
 
-   //
-   // Instantiate the device
-   //
-   var device = deviceModule.DeviceClient(options);
+   // Allow reuse of the device client by passing options.device
+   if (!isUndefined(options.device) && typeof options.device === "object")
+   {
+      console.log(typeof(options.device));
+      var device = options.device;
+   } else {
+      //
+      // Instantiate the device
+      //
+      var device = deviceModule.DeviceClient(options);
+
+   }
 
    //
    // Private function to update job execution status for given thing

--- a/thing/index.js
+++ b/thing/index.js
@@ -120,7 +120,6 @@ function ThingShadowsClient(deviceOptions, thingShadowOptions) {
    // Allow reuse of the device client by passing options.device
    if (!isUndefined(deviceOptions.device) && typeof deviceOptions.device === "object")
    {
-      console.log(typeof(deviceOptions.device));
       var device = deviceOptions.device;
    } else {
       //

--- a/thing/index.js
+++ b/thing/index.js
@@ -117,10 +117,17 @@ function ThingShadowsClient(deviceOptions, thingShadowOptions) {
    //
    var connected = true;
 
-   //
-   // Instantiate the device.
-   //
-   var device = deviceModule.DeviceClient(deviceOptions);
+   // Allow reuse of the device client by passing options.device
+   if (!isUndefined(deviceOptions.device) && typeof deviceOptions.device === "object")
+   {
+      console.log(typeof(deviceOptions.device));
+      var device = deviceOptions.device;
+   } else {
+      //
+      // Instantiate the device
+      //
+      var device = deviceModule.DeviceClient(deviceOptions);
+   }
 
    if (!isUndefined(thingShadowOptions)) {
       if (!isUndefined(thingShadowOptions.operationTimeout)) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modified the creation method of the thingShadow and jobs class to allow an option to be passed 'device' which is a pre-existing device object.  This fixes the problem where you cannot simultaneously use the jobs functionality with the thingShadow functionality without having multiple connections with different client IDs (or manually re-creating one of these functionalities with base MQTT subscribe/publishes).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
