### PR TITLE
Pass optional headers for iot custom authorizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "mqtt"
   ],
   "dependencies": {
-    "mqtt": "2.18.8",
+    "crypto-js": "3.1.6",
     "minimist": "1.2.5",
-    "websocket-stream": "^5.0.1",
-    "crypto-js": "3.1.6"
+    "mqtt": "2.18.8",
+    "websocket-stream": "git+https://github.com/rrrhys/websocket-stream.git"
   },
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "crypto-js": "3.1.6",
     "minimist": "1.2.5",
     "mqtt": "2.18.8",
-    "websocket-stream": "git+https://github.com/rrrhys/websocket-stream.git"
+    "websocket-stream": "github:frank10gm/websocket-stream#feature/pass-optional-headers"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
Modified dependency:
Custom version of websocket-stream, in order to pass optional headers when using IoT Core Custom Authorizer.
PR to websocket-stream already made.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
