### PR TITLE
Require only the necessary modules from crypto-js to optimize bundle

### DIFF
--- a/device/index.js
+++ b/device/index.js
@@ -19,7 +19,8 @@ var inherits = require('util').inherits;
 
 //npm deps
 var mqtt = require('mqtt');
-var crypto = require('crypto-js');
+var HmacSHA256 = require("crypto-js/hmac-sha256");
+var SHA256 = require("crypto-js/sha256");
 
 //app deps
 var exceptions = require('./lib/exceptions');
@@ -57,16 +58,16 @@ function getDateString(dateTimeString) {
 }
 
 function getSignatureKey(key, dateStamp, regionName, serviceName) {
-   var kDate = crypto.HmacSHA256(dateStamp, 'AWS4' + key, {
+   var kDate = HmacSHA256(dateStamp, 'AWS4' + key, {
       asBytes: true
    });
-   var kRegion = crypto.HmacSHA256(regionName, kDate, {
+   var kRegion = HmacSHA256(regionName, kDate, {
       asBytes: true
    });
-   var kService = crypto.HmacSHA256(serviceName, kRegion, {
+   var kService = HmacSHA256(serviceName, kRegion, {
       asBytes: true
    });
-   var kSigning = crypto.HmacSHA256('aws4_request', kService, {
+   var kSigning = HmacSHA256('aws4_request', kService, {
       asBytes: true
    });
    return kSigning;
@@ -85,7 +86,7 @@ function signUrl(method, scheme, hostname, path, queryParams, accessId, secretKe
       canonicalHeaders + // headers
       '\n' + // required
       signedHeaders + '\n' + // signed header list
-      crypto.SHA256(payload, {
+      SHA256(payload, {
          asBytes: true
       }); // hash of payload (empty string)
 
@@ -93,7 +94,7 @@ function signUrl(method, scheme, hostname, path, queryParams, accessId, secretKe
       console.log('canonical request: ' + canonicalRequest + '\n');
    }
 
-   var hashedCanonicalRequest = crypto.SHA256(canonicalRequest, {
+   var hashedCanonicalRequest = SHA256(canonicalRequest, {
       asBytes: true
    });
 
@@ -116,7 +117,7 @@ function signUrl(method, scheme, hostname, path, queryParams, accessId, secretKe
       console.log('signing key: ' + signingKey + '\n');
    }
 
-   var signature = crypto.HmacSHA256(stringToSign, signingKey, {
+   var signature = HmacSHA256(stringToSign, signingKey, {
       asBytes: true
    });
 


### PR DESCRIPTION
*Issue #, if available:*
The crypto-js module is currently 30% of this package when bundled.
[https://bundlephobia.com/result?p=aws-iot-device-sdk@2.2.4](https://bundlephobia.com/result?p=aws-iot-device-sdk@2.2.4)

*Description of changes:*
Rather than requiring the entire crypto-js libary, this change requires just the specific components of crypto-js that are utilized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
