### PR TITLE
Add missing reconnect feature available in mqtt.js 

### DIFF
--- a/device/index.js
+++ b/device/index.js
@@ -889,6 +889,10 @@ function DeviceClient(options) {
       device.end(force, callback);
    };
 
+   this.reconnect = function(){
+      device.reconnect()
+   };
+
    this.handleMessage = device.handleMessage.bind(device);
 
    device.handleMessage = function(packet, callback) {


### PR DESCRIPTION
*Description of changes:*
In mqtt.js there is the possibility to force the reconnection, which is useful in certain occasions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
