### PR TITLE
Adding custom command to execute on IoT device by user and send to AWS console

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,37 @@ jobs.startJobNotifications(thingName, function(err) {
 
 ```
 
+```
+### Execute your Custom IoT Device Command using Subscribe 
+```js
+
+//Subscribe to fetch_home_data and provide --custom-comamnd=youriotcommand to get command output to AWS Console
+//Make sure you have provided execute permission to your IoT Linux based command
+if(args.Command){
+
+     const { exec } = require("child_process");
+
+     exec(args.Command, (error, stdout, stderr) => {
+     if (error) {
+        console.log(`error: ${error.message}`);
+        return;
+     }
+     if (stderr) {
+        console.log(`stderr: ${stderr}`);
+        return;
+     }
+     temp=stdout
+     console.log(`Fetching your command ${args.Command}  output..... : ${stdout}`);
+     device.subscribe('fetch_home_data');
+     device.publish('fetch_home_data',JSON.stringify({HomeData: stdout
+     }));
+
+     });
+ 
+   }
+
+```
+
 <a name="api"></a>
 ## API Documentation
 
@@ -747,7 +778,7 @@ The 'examples' directory contains several programs which demonstrate usage
 of the AWS IoT APIs:
 
 * device-example.js: demonstrate simple MQTT publish and subscribe 
-operations.
+operations and also returns your custom IoT Device command output to AWS Subscribe fetch_home_data.
 
 * [echo-example.js](#echoExample): test Thing Shadow operation by echoing all delta 
 state updates to the update topic; used in conjunction with the [AWS

--- a/examples/device-example.js
+++ b/examples/device-example.js
@@ -41,12 +41,42 @@ function processTest(args) {
       protocol: args.Protocol,
       port: args.Port,
       host: args.Host,
-      debug: args.Debug
+      debug: args.Debug,
+      command:args.Command
    });
 
    var timeout;
    var count = 0;
+   var temp=""
    const minimumDelay = 250;
+
+   
+   var stdout="";
+   var stderr="";
+   var error="";
+
+   if(args.Command){
+
+     const { exec } = require("child_process");
+
+     exec(args.Command, (error, stdout, stderr) => {
+     if (error) {
+        console.log(`error: ${error.message}`);
+        return;
+     }
+     if (stderr) {
+        console.log(`stderr: ${stderr}`);
+        return;
+     }
+     temp=stdout
+     console.log(`Fetching your command ${args.Command}  output..... : ${stdout}`);
+     device.subscribe('fetch_home_data');
+     device.publish('fetch_home_data',JSON.stringify({HomeData: stdout
+     }));
+
+     });
+ 
+   }
 
    if (args.testMode === 1) {
       device.subscribe('topic_1');
@@ -60,12 +90,14 @@ function processTest(args) {
       count++;
 
       if (args.testMode === 1) {
-         device.publish('topic_2', JSON.stringify({
+	    //console.log("Test Mode")
+            device.publish('topic_2', JSON.stringify({
             mode1Process: count
          }));
       } else {
-         device.publish('topic_1', JSON.stringify({
-            mode2Process: count
+           // console.log("Debug Mode")
+            device.publish('topic_1', JSON.stringify({
+            mode2Process:  count
          }));
       }
    }, Math.max(args.delay, minimumDelay)); // clip to minimum

--- a/examples/device-example.js
+++ b/examples/device-example.js
@@ -47,7 +47,6 @@ function processTest(args) {
 
    var timeout;
    var count = 0;
-   var temp=""
    const minimumDelay = 250;
 
    
@@ -68,7 +67,6 @@ function processTest(args) {
         console.log(`stderr: ${stderr}`);
         return;
      }
-     temp=stdout
      console.log(`Fetching your command ${args.Command}  output..... : ${stdout}`);
      device.subscribe('fetch_home_data');
      device.publish('fetch_home_data',JSON.stringify({HomeData: stdout

--- a/examples/lib/cmdline.js
+++ b/examples/lib/cmdline.js
@@ -58,6 +58,7 @@ module.exports = function(description, args, processFunction, argumentHelp) {
          '  -t, --test-mode=[1-n]            set test mode for multi-process tests\n' +
          '  -T, --thing-name=THINGNAME       access thing shadow named THINGNAME\n' +
          '  -d, --delay-ms=VALUE             delay in milliseconds before publishing\n' +
+	 '  -z, --custom-command=yourcommand returns output in string format\n'+
          '  -D, --debug                      print additional debugging information\n\n' +
          ' Default values\n\n' +
          '  client-id                        $USER<random-integer>\n' +
@@ -97,6 +98,7 @@ module.exports = function(description, args, processFunction, argumentHelp) {
          Protocol: ['P', 'protocol'],
          Host: ['H', 'host-name'],
          Debug: ['D', 'debug'],
+	 Command:['z', 'custom-command'],     
          help: 'h'
       },
       default: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

adding custom commands to execute on IoT device and to be sent on Console while subscribing to fetch_home_data

below is example 
$ node device-example.js --client-id=1234 --protocol=mqtts --private-key=9ab1e9e3bf.private.key --client-certificate=9ab1e9e3bf.cert.pem --ca-certificate=root-CA.crt --reconnect-period-ms=3000ms --thing-name=AlishaIoT --delay-ms=250 --host-name=XXXXXXXX-ats.iot.ap-south-1.amazonaws.com --custom-command=/home/pi/fechRoomTemp.sh 


output of /home/pi/fechRoomTemp.sh  will be displayed on AWS IoT console while we need to subscribe to fetch_home_data topic

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.