### PR TITLE
wss-custom-auth: Allow authorization using queryString.

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ follows:
   * `secretKey`: used to specify the Secret Key when `protocol` is set to 'wss'.  Overrides the environment variable `AWS_SECRET_ACCESS_KEY`and `AWS_SECRET_ACCESS_KEY`  from `filename` if set.
   * `sessionToken`: (required when authenticating via Cognito, optional otherwise) used to specify the Session Token when `protocol` is set to 'wss'.  Overrides the environment variable `AWS_SESSION_TOKEN` if set.
   * `customAuthHeaders`: used to specify your custom authorization headers when `protocol` is set to 'wss-custom-auth'. The fields 'X-Amz-CustomAuthorizer-Name', 'X-Amz-CustomAuthorizer-Signature', and the field for your token name are required.
+  * `customAuthQueryString`: used to specify the token credentials in a query string for custom authorization when `protocol` is set to `wss-custom-auth`. More info can be found [here](https://docs.aws.amazon.com/iot/latest/developerguide/custom-auth.html#custom-auth-websockets).
   * `keepalive`: used to specify the time interval for each ping request. Default is set to 300 seconds to connect to AWS IoT.
   * `enableMetrics`: used to report SDK version usage metrics. It is set to true by default. To disable metrics collection, set value to false.
 
@@ -729,8 +730,8 @@ set the `protocol` option to `wss-custom-auth`.
 ### Custom Authorization Configuration
 
 To use custom authorization, you must first set up an authorizer function in Lambda and register it
-with IoT. Once you do, you will be able to authenticate using this function. To use custom auth,
-set the `customAuthHeaders` option to your headers object when instantiating the [awsIotDevice()](#device)
+with IoT. Once you do, you will be able to authenticate using this function. There are two ways to use custom auth:
+* set the `customAuthHeaders` option to your headers object when instantiating the [awsIotDevice()](#device)
 or [awsIot.thingShadow()](#thingShadow) classes. The headers object is an object containing the header name
 and values as key-value pairs:
 
@@ -740,6 +741,11 @@ and values as key-value pairs:
         'X-Amz-CustomAuthorizer-Signature': 'signature',
         'TestAuthorizerToken': 'token'
     }
+```
+* set the `customAuthQueryString` option to your headers object when instantiating the [awsIotDevice()](#device) class. The query string is a string containing the values as key-value pairs:
+
+```js
+    '?X-Amz-CustomAuthorizer-Name=TestAuthorizer&X-Amz-CustomAuthorizer-Signature=signature&TestAuthorizerToken=token'
 ```
 
 

--- a/device/index.js
+++ b/device/index.js
@@ -172,7 +172,7 @@ function prepareWebSocketCustomAuthUrl(options) {
       hostName = options.host + ':' + options.port;
    }
 
-   return 'wss://' + hostName + path;
+   return 'wss://' + hostName + path + (options.customAuthQueryString || '');
 }
 
 function arrayEach(array, iterFunction) {
@@ -505,8 +505,8 @@ function DeviceClient(options) {
             throw new Error(exceptions.INVALID_CONNECT_OPTIONS);
          }
       } else {
-         if (isUndefined(options.customAuthHeaders)) {
-            console.log('To authenticate with a custom authorizer, you must provide the required HTTP headers; see README.md');
+         if (isUndefined(options.customAuthHeaders) && isUndefined(options.customAuthQueryString)) {
+            console.log('To authenticate with a custom authorizer, you must provide the required HTTP headers or queryString; see README.md');
             throw new Error(exceptions.INVALID_CONNECT_OPTIONS);
          }
       }

--- a/test/device-unit-tests.js
+++ b/test/device-unit-tests.js
@@ -545,12 +545,36 @@ describe( "device class unit tests", function() {
          );
       });
    });
-   describe("device throws exception if using CustomAuth over websocket without headers", function () {
+   describe("device throws exception if using CustomAuth over websocket without headers or querystring", function () {
       it("throws exception", function () {
          assert.throws(function (err) {
             var device = deviceModule({
                host: 'XXXX.iot.us-east-1.amazonaws.com',
                protocol: 'wss-custom-auth'
+            });
+         }, function (err) { console.log('\t[' + err + ']'); return true; }
+         );
+      });
+   });
+   describe("device does not throw exception if using CustomAuth over websocket with headers", function () {
+      it("does not throw an exception", function () {
+         assert.doesNotThrow(function (err) {
+            var device = deviceModule({
+               host: 'XXXX.iot.us-east-1.amazonaws.com',
+               protocol: 'wss-custom-auth',
+               customAuthHeaders: {}
+            });
+         }, function (err) { console.log('\t[' + err + ']'); return true; }
+         );
+      });
+   });
+   describe("device does not throw exception if using CustomAuth over websocket with querystring", function () {
+      it("does not throw an exception", function () {
+         assert.doesNotThrow(function (err) {
+            var device = deviceModule({
+               host: 'XXXX.iot.us-east-1.amazonaws.com',
+               protocol: 'wss-custom-auth',
+               customAuthQueryString: ''
             });
          }, function (err) { console.log('\t[' + err + ']'); return true; }
          );
@@ -1886,6 +1910,15 @@ describe( "device class unit tests", function() {
          var url = deviceModule.prepareWebSocketCustomAuthUrl( { host:'not-a-real-host.com' } );
          assert.equal( url, expectedUrl );
       });
+   });
+   describe("websocket http querystring is correctly set when CustomAuth querystring is specified", function() {
+      it("generates the correct url", function() {
+         const queryString = '?X-Amz-CustomAuthorizer-Name=AuthorizerFunctionName&X-Amz-CustomAuthorizer-Signature=Signature&NPAuthorizerToken=Token';
+         const expectedUrl = 'wss://not-a-real-host.com/mqtt' + queryString;
+         const url = deviceModule.prepareWebSocketCustomAuthUrl( { host:'not-a-real-host.com', customAuthQueryString: queryString } );
+         assert.equal( url, expectedUrl );
+      });
+      
    });
    describe("websocket headers are correctly set when CustomAuth headers are specified", function() {
       it("sets the websocket headers correctly", function() {


### PR DESCRIPTION
*Issue #, if available:* #169 

*Description of changes:*
Added support for authenticating clients run in a browser environment which strips headers for WebSocket HTTP upgrade requests. Using the query string to pass the authentication information circumvents this limitation allowing the sdk to connect to AWS IoT using custom authentication in a browser client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
