### PR TITLE
Relicense sample code in README to MIT-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ ignore anything passed in programmatically.
 
 ### Device Class
 ```js
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 var awsIot = require('aws-iot-device-sdk');
 
 //
@@ -127,8 +129,11 @@ device
     console.log('message', topic, payload.toString());
   });
 ```
+
 ### Thing Shadow Class
 ```js
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 var awsIot = require('aws-iot-device-sdk');
 
 //
@@ -222,6 +227,8 @@ thingShadows.on('timeout',
 ```
 ### Jobs Class
 ```js
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 var awsIot = require('aws-iot-device-sdk');
 
 //


### PR DESCRIPTION
*Description of changes:*

MIT-0 is a more permissive license which makes it easier to reason about writing your own code based on a sample.
I looked through the history of the README.md file and it looks like there haven't been any substantive contributions from outside of Amazon, so the relicense of these samples should be fine.

Note that this applies *only* to the sample codes in the README. The rest of the code in the repository remains under other licenses (Apache-2.0).
