### PR TITLE
Unset AWS_PROFILE before relevant unit tests

### DIFF
--- a/test/device-unit-tests.js
+++ b/test/device-unit-tests.js
@@ -404,6 +404,7 @@ describe( "device class unit tests", function() {
 
          delete process.env.AWS_ACCESS_KEY_ID;
          delete process.env.AWS_SECRET_ACCESS_KEY;
+         delete process.env.AWS_PROFILE;
 
          assert.doesNotThrow( function( err ) { 
             var device = deviceModule( {


### PR DESCRIPTION
* Remove AWS_PROFILE from the process environment in a test that is affected by its presence.  Addresses https://github.com/aws/aws-iot-device-sdk-js/issues/283

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
