### PR TITLE
Required when there is no file system ('fs')

### DIFF
--- a/common/lib/tls-reader.js
+++ b/common/lib/tls-reader.js
@@ -52,54 +52,51 @@ module.exports = function(options) {
    if (!isUndefined(options.caCert)) {
       if (Buffer.isBuffer(options.caCert)) {
          options.ca = options.caCert;
+      } else if (filesys.existsSync && filesys.existsSync(options.caCert)) {
+         options.ca = filesys.readFileSync(options.caCert);
       } else {
-         if (filesys.existsSync(options.caCert)) {
-            options.ca = filesys.readFileSync(options.caCert);
-         } else {
-            throw new Error(exceptions.INVALID_CA_CERT_OPTION);
-         }
+         throw new Error(exceptions.INVALID_CA_CERT_OPTION);
       }
    }
    if (!isUndefined(options.privateKey)) {
       if (Buffer.isBuffer(options.privateKey)) {
          options.key = options.privateKey;
+      } else if (filesys.existsSync && filesys.existsSync(options.privateKey)) {
+         options.key = filesys.readFileSync(options.privateKey);
       } else {
-         if (filesys.existsSync(options.privateKey)) {
-            options.key = filesys.readFileSync(options.privateKey);
-         } else {
-            throw new Error(exceptions.INVALID_PRIVATE_KEY_OPTION);
-         }
+         throw new Error(exceptions.INVALID_PRIVATE_KEY_OPTION);
       }
+
    }
    if (!isUndefined(options.clientCert)) {
       if (Buffer.isBuffer(options.clientCert)) {
          options.cert = options.clientCert;
+      } else if (filesys.existsSync && filesys.existsSync(options.clientCert)) {
+         options.cert = filesys.readFileSync(options.clientCert);
       } else {
-         if (filesys.existsSync(options.clientCert)) {
-            options.cert = filesys.readFileSync(options.clientCert);
-         } else {
-            throw new Error(exceptions.INVALID_CLIENT_CERT_OPTION);
-         }
+         throw new Error(exceptions.INVALID_CLIENT_CERT_OPTION);
       }
    }
 
    // Parse PEM files.  Options ending in 'Path' must be files
    // and will override options which do not end in 'Path'.
 
-   if (filesys.existsSync(options.keyPath)) {
-      options.key = filesys.readFileSync(options.keyPath);
-   } else if (!isUndefined(options.keyPath)) {
-      throw new Error(exceptions.INVALID_KEY_PATH_OPTION);
-   }
-   if (filesys.existsSync(options.certPath)) {
-      options.cert = filesys.readFileSync(options.certPath);
-   } else if (!isUndefined(options.certPath)) {
-      throw new Error(exceptions.INVALID_CERT_PATH_OPTION);
-   }
-   if (filesys.existsSync(options.caPath)) {
-      options.ca = filesys.readFileSync(options.caPath);
-   } else if (!isUndefined(options.caPath)) {
-      throw new Error(exceptions.INVALID_CA_PATH_OPTION);
+   if (filesys.existsSync) {
+      if (filesys.existsSync(options.keyPath)) {
+         options.key = filesys.readFileSync(options.keyPath);
+      } else if (!isUndefined(options.keyPath)) {
+         throw new Error(exceptions.INVALID_KEY_PATH_OPTION);
+      }
+      if (filesys.existsSync(options.certPath)) {
+         options.cert = filesys.readFileSync(options.certPath);
+      } else if (!isUndefined(options.certPath)) {
+         throw new Error(exceptions.INVALID_CERT_PATH_OPTION);
+      }
+      if (filesys.existsSync(options.caPath)) {
+         options.ca = filesys.readFileSync(options.caPath);
+      } else if (!isUndefined(options.caPath)) {
+         throw new Error(exceptions.INVALID_CA_PATH_OPTION);
+      }
    }
 
    // request certificate from partner


### PR DESCRIPTION
*Issue #, if available:*
Required when there is no file system ('fs') and the certificate is embedded in the code

*Description of changes:*
Certificates are already passed in the buffer, from a string

Exemple of use:

const client_privkey = `-----BEGIN RSA PRIVATE KEY-----
.......................
-----END RSA PRIVATE KEY-----`;

const client = new device({
    privateKey: Buffer.from(client_privkey),
...


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.