### PR TITLE
typo: use var instead of const

### DIFF
--- a/device/lib/ws.js
+++ b/device/lib/ws.js
@@ -16,7 +16,7 @@
 //node.js deps
 
 //npm deps
-const websocket = require('websocket-stream');
+var websocket = require('websocket-stream');
 
 //app deps
 


### PR DESCRIPTION
should keep code as es5 across files. If mixed es5 and es6 code, it' hard to compile or not in build tool like webpack. maybe has the same issue in somewhere, please double check.

