### PR TITLE
Fixing warning: "Passing invalid argument types to fs.existsSync is eprecated"

### DIFF
--- a/common/lib/tls-reader.js
+++ b/common/lib/tls-reader.js
@@ -86,20 +86,26 @@ module.exports = function(options) {
    // Parse PEM files.  Options ending in 'Path' must be files
    // and will override options which do not end in 'Path'.
 
-   if (filesys.existsSync(options.keyPath)) {
-      options.key = filesys.readFileSync(options.keyPath);
-   } else if (!isUndefined(options.keyPath)) {
-      throw new Error(exceptions.INVALID_KEY_PATH_OPTION);
+   if (!isUndefined(options.keyPath)) {
+      if (filesys.existsSync(options.keyPath)) {
+         options.key = filesys.readFileSync(options.keyPath);
+      } else {
+         throw new Error(exceptions.INVALID_KEY_PATH_OPTION);
+      }
    }
-   if (filesys.existsSync(options.certPath)) {
-      options.cert = filesys.readFileSync(options.certPath);
-   } else if (!isUndefined(options.certPath)) {
-      throw new Error(exceptions.INVALID_CERT_PATH_OPTION);
+   if (!isUndefined(options.certPath)) {
+      if (filesys.existsSync(options.certPath)) {
+         options.cert = filesys.readFileSync(options.certPath);
+      } else {
+         throw new Error(exceptions.INVALID_CERT_PATH_OPTION);
+      }
    }
-   if (filesys.existsSync(options.caPath)) {
-      options.ca = filesys.readFileSync(options.caPath);
-   } else if (!isUndefined(options.caPath)) {
-      throw new Error(exceptions.INVALID_CA_PATH_OPTION);
+   if (!isUndefined(options.caPath)) {
+      if (filesys.existsSync(options.caPath)) {
+         options.ca = filesys.readFileSync(options.caPath);
+      } else {
+         throw new Error(exceptions.INVALID_CA_PATH_OPTION);
+      }
    }
 
    // request certificate from partner


### PR DESCRIPTION
*Description of changes:*

Since Node.js v24, `fs.existsSync()` will log the following deprecation warning if passed undefined.

```
(node:4199) [DEP0187] DeprecationWarning: Passing invalid argument types to fs.existsSync is deprecated
```

Here is an example full stack trace I've seen using `--trace-deprecation`

```
(node:4199) [DEP0187] DeprecationWarning: Passing invalid argument types to fs.existsSync is deprecated
    at Object.existsSync (node:fs:282:15)
    at module.exports (/var/lib/homebridge/node_modules/@homebridge-plugins/homebridge-govee/node_modules/aws-iot-device-sdk/common/lib/tls-reader.js:89:16)
    at new DeviceClient (/var/lib/homebridge/node_modules/@homebridge-plugins/homebridge-govee/node_modules/aws-iot-device-sdk/device/index.js:461:7)
    at DeviceClient (/var/lib/homebridge/node_modules/@homebridge-plugins/homebridge-govee/node_modules/aws-iot-device-sdk/device/index.js:217:14)
    at new default (file:///var/lib/homebridge/node_modules/@homebridge-plugins/homebridge-govee/lib/connection/aws.js:16:19)
    at default.pluginSetup (file:///var/lib/homebridge/node_modules/@homebridge-plugins/homebridge-govee/lib/platform.js:487:28)
```

The root cause is that we need to check the existence of `options.keyPath` before calling `filesys.existsSync()`

While I haven't seen it in the real world, the same is probably true of `options.certPath` and `options.caPath`

This PR checks the existence of those params first before calling `existsSync()` to avoid the deprecation warning.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
